### PR TITLE
Handling trivy and dockle vulnerabilities

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -5,8 +5,9 @@ inputs:
     description: 'Docker image to scan'
     required: true
   severity-threshold:
-    description: 'severities of vulnerabilities to be displayed (UNKNOWN,LOW,MEDIUM,HIGH,CRITICAL)'
+    description: 'Severities of vulnerabilities to be displayed (UNKNOWN,LOW,MEDIUM,HIGH,CRITICAL)'
     required: false
+    default: 'HIGH'
   username:
     description: 'Username to authenticate to the Docker registry'
     required: false

--- a/action.yaml
+++ b/action.yaml
@@ -5,7 +5,7 @@ inputs:
     description: 'Docker image to scan'
     required: true
   severity-threshold:
-    description: 'Severities of vulnerabilities to be displayed (UNKNOWN,LOW,MEDIUM,HIGH,CRITICAL)'
+    description: 'Minimum severities of vulnerabilities to be displayed (UNKNOWN,LOW,MEDIUM,HIGH,CRITICAL)'
     required: false
     default: 'HIGH'
   username:

--- a/lib/dockleHelper.js
+++ b/lib/dockleHelper.js
@@ -38,6 +38,8 @@ const TITLE_VULNERABILITY_ID = "VULNERABILITY ID";
 const TITLE_TITLE = "TITLE";
 const TITLE_SEVERITY = "SEVERITY";
 const TITLE_DESCRIPTION = "DESCRIPTION";
+const LEVEL_IGNORE = "IGNORE";
+const LEVEL_INFO = "INFO";
 function getDockle() {
     return __awaiter(this, void 0, void 0, function* () {
         const latestDockleVersion = yield getLatestDockleVersion();
@@ -140,12 +142,14 @@ function printFormattedOutput() {
     let titles = [TITLE_VULNERABILITY_ID, TITLE_TITLE, TITLE_SEVERITY, TITLE_DESCRIPTION];
     rows.push(titles);
     dockleOutputJson[KEY_DETAILS].forEach(ele => {
-        let row = [];
-        row.push(ele[KEY_CODE]);
-        row.push(ele[KEY_TITLE]);
-        row.push(ele[KEY_LEVEL]);
-        row.push(ele[KEY_ALERTS][0]);
-        rows.push(row);
+        if (ele[KEY_LEVEL] != LEVEL_IGNORE && ele[KEY_LEVEL] != LEVEL_INFO) {
+            let row = [];
+            row.push(ele[KEY_CODE]);
+            row.push(ele[KEY_TITLE]);
+            row.push(ele[KEY_LEVEL]);
+            row.push(ele[KEY_ALERTS][0]);
+            rows.push(row);
+        }
     });
     let widths = [25, 25, 25, 60];
     console.log(table.table(rows, utils.getConfigForTable(widths)));

--- a/src/dockleHelper.ts
+++ b/src/dockleHelper.ts
@@ -21,6 +21,8 @@ const TITLE_VULNERABILITY_ID = "VULNERABILITY ID";
 const TITLE_TITLE = "TITLE";
 const TITLE_SEVERITY = "SEVERITY";
 const TITLE_DESCRIPTION = "DESCRIPTION";
+const LEVEL_IGNORE = "IGNORE";
+const LEVEL_INFO = "INFO";
 
 export async function getDockle(): Promise<string> {
     const latestDockleVersion = await getLatestDockleVersion();
@@ -134,14 +136,16 @@ export function printFormattedOutput() {
     let titles = [TITLE_VULNERABILITY_ID, TITLE_TITLE, TITLE_SEVERITY, TITLE_DESCRIPTION];
     rows.push(titles);
     dockleOutputJson[KEY_DETAILS].forEach(ele => {
-                let row = [];
-                row.push(ele[KEY_CODE]);
-                row.push(ele[KEY_TITLE]);
-                row.push(ele[KEY_LEVEL]);
-                row.push(ele[KEY_ALERTS][0]);
-                rows.push(row);           
+        if (ele[KEY_LEVEL] != LEVEL_IGNORE && ele[KEY_LEVEL] != LEVEL_INFO) {
+            let row = [];
+            row.push(ele[KEY_CODE]);
+            row.push(ele[KEY_TITLE]);
+            row.push(ele[KEY_LEVEL]);
+            row.push(ele[KEY_ALERTS][0]);
+            rows.push(row);
+        }
     });
-    
+
     let widths = [25, 25, 25, 60];
     console.log(table.table(rows, utils.getConfigForTable(widths)));
 }


### PR DESCRIPTION
1. Default severity threshold set to HIGH for trivy
2. Default level for dockle set to WARN
3. Removed dockle vulnerabilities with level IGNORE in logs